### PR TITLE
Clean root when update query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.2.0] - 2019-10-16
 ### Changed
+- Emit "clean" event over root instance when an "update" is executed on any queried instance. (Full object is modified too).
 - Upgrade mercury version and define it as peer dependency.
 - Upgrade devDependencies.
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,9 @@ npm i @xbyorange/mercury-browser-storage --save
 * Arguments
   * key - `<String>` Key of the storage object to be read, updated, created or deleted.
 
-### cache
+## Cache
 
-The `clean` events will be dispatched when the `update`, `delete` or `create` methods are executed for an specific query as in other mercury origins:
-
-* If `update` or `delete` methods are executed over the origin without query, cache of all queried resources will be cleaned too.
-* All `cache` will be cleaned if the `create` method is executed.
+All cache will be cleaned when the `update`, `delete` or `create` methods are executed for any specific query.
 
 ## Examples
 

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -62,7 +62,7 @@ export class Storage extends Origin {
       rootValue = data;
     }
     this._setRootValue(rootValue);
-    this._clean(filter);
+    this._clean();
     return Promise.resolve();
   }
 

--- a/test/local-storage-methods.spec.js
+++ b/test/local-storage-methods.spec.js
@@ -152,24 +152,25 @@ describe("Local Storage", () => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
       userData = new LocalStorage("userData", {}, storage.mock);
     });
-
-    it("should clean the cache when finish successfully", async () => {
-      expect.assertions(3);
-      let promise = userData.read();
-      expect(userData.read.loading).toEqual(true);
-      await promise;
-      await userData.update("");
-      promise = userData.read();
-      expect(userData.read.loading).toEqual(true);
-      return promise.then(() => {
-        expect(userData.read.loading).toEqual(false);
+    describe("without query", () => {
+      it("should clean the cache when finish successfully", async () => {
+        expect.assertions(3);
+        let promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        await promise;
+        await userData.update("");
+        promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        return promise.then(() => {
+          expect(userData.read.loading).toEqual(false);
+        });
       });
-    });
 
-    it("should set the new value", async () => {
-      const newValue = { foo2: "foo-new-value" };
-      await userData.update(newValue);
-      expect(storage.stubs.setItem.getCall(0).args[1]).toEqual(JSON.stringify(newValue));
+      it("should set the new value", async () => {
+        const newValue = { foo2: "foo-new-value" };
+        await userData.update(newValue);
+        expect(storage.stubs.setItem.getCall(0).args[1]).toEqual(JSON.stringify(newValue));
+      });
     });
 
     describe("when queried", () => {
@@ -181,6 +182,19 @@ describe("Local Storage", () => {
             foo: "foo-updated-value"
           })
         );
+      });
+
+      it("should clean the cache of root when finish successfully", async () => {
+        expect.assertions(3);
+        let promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        await promise;
+        await userData.query("foo").update("");
+        promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        return promise.then(() => {
+          expect(userData.read.loading).toEqual(false);
+        });
       });
     });
   });

--- a/test/session-storage-methods.spec.js
+++ b/test/session-storage-methods.spec.js
@@ -122,23 +122,25 @@ describe("SessionStorage Storage", () => {
       userData = new SessionStorage("userData", {}, storage.mock);
     });
 
-    it("should clean the cache when finish successfully", async () => {
-      expect.assertions(3);
-      let promise = userData.read();
-      expect(userData.read.loading).toEqual(true);
-      await promise;
-      await userData.update("");
-      promise = userData.read();
-      expect(userData.read.loading).toEqual(true);
-      return promise.then(() => {
-        expect(userData.read.loading).toEqual(false);
+    describe("without query", () => {
+      it("should clean the cache when finish successfully", async () => {
+        expect.assertions(3);
+        let promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        await promise;
+        await userData.update("");
+        promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        return promise.then(() => {
+          expect(userData.read.loading).toEqual(false);
+        });
       });
-    });
 
-    it("should set the new value", async () => {
-      const newValue = { foo2: "foo-new-value" };
-      await userData.update(newValue);
-      expect(storage.stubs.setItem.getCall(0).args[1]).toEqual(JSON.stringify(newValue));
+      it("should set the new value", async () => {
+        const newValue = { foo2: "foo-new-value" };
+        await userData.update(newValue);
+        expect(storage.stubs.setItem.getCall(0).args[1]).toEqual(JSON.stringify(newValue));
+      });
     });
 
     describe("when queried", () => {
@@ -150,6 +152,19 @@ describe("SessionStorage Storage", () => {
             foo: "foo-updated-value"
           })
         );
+      });
+
+      it("should clean the cache of root when finish successfully", async () => {
+        expect.assertions(3);
+        let promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        await promise;
+        await userData.query("foo").update("");
+        promise = userData.read();
+        expect(userData.read.loading).toEqual(true);
+        return promise.then(() => {
+          expect(userData.read.loading).toEqual(false);
+        });
       });
     });
   });


### PR DESCRIPTION
### Changed
- Emit "clean" event over root instance when an "update" is executed on any queried instance. (Full object is modified too).