### PR TITLE
Queries default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### BREAKING CHANGES
 
 ## [1.2.0] - 2019-10-16
+### Added
+- Add "queriesDefaultValue" option. If defined, queried instances will have default value corresponding to the value of query "key" in the default value object. If not, the behavior of "default value" will be the same than in previous versions, and will return the full object even for queried instances)
+- Add "tags" option.
+
 ### Changed
 - Emit "clean" event over root instance when an "update" is executed on any queried instance. (Full object is modified too).
 - Upgrade mercury version and define it as peer dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [TO BE DEPRECATED]
+- "queriesDefaultValue" option has to be removed.
+
 ## [1.2.0] - 2019-10-16
 ### Added
 - Add "queriesDefaultValue" option. If defined, queried instances will have default value corresponding to the value of query "key" in the default value object. If not, the behavior of "default value" will be the same than in previous versions, and will return the full object even for queried instances)

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ npm i @xbyorange/mercury-browser-storage --save
 
 ## Api
 
-* SessionStorage - _`<Class>`_ `new SessionStorage(namespace[, defaultValue])` - Class for instancing mercury objects persisted in the browser sessionStorage.
+* SessionStorage - _`<Class>`_ `new SessionStorage(namespace[, defaultValue[, options]])` - Class for instancing mercury objects persisted in the browser sessionStorage.
 	* Arguments
 		* namespace - _`<String>`_. Namespace to be used in the sessionStorage object, in which the origin data will be persisted.
 		* defaultValue - _`<Any>`_ Default value until the first async read is resolved.
-* LocalStorage - _`<Class>`_ `new LocalStorage(namespace[, defaultValue])` - Class for instancing mercury objects persisted in the browser localStorage.
+* LocalStorage - _`<Class>`_ `new LocalStorage(namespace[, defaultValue[, options]])` - Class for instancing mercury objects persisted in the browser localStorage.
 	* Arguments
 		* namespace - _`<String>`_. Namespace to be used in the localStorage object, in which the origin data will be persisted.
 		* defaultValue - _`<Any>`_ Default value until the first async read is resolved.
@@ -107,12 +107,21 @@ await currentAuthorBooks.read();
 
 ```
 
+## Usage with frameworks
+
+### React
+
+Please refer to the [react-mercury][react-mercury-url] documentation to see how simple is the data-binding between React Components and Mercury Browser Storage.
+
+Connect a source to all components that need it. Mercury will rerender automatically connected components when data in sources is updated.
+
 ## Contributing
 
 Contributors are welcome.
 Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of conduct](.github/CODE_OF_CONDUCT.md).
 
 [mercury-url]: https://github.com/xbyorange/mercury
+[react-mercury-url]: https://github.com/xbyorange/react-mercury
 
 [coveralls-image]: https://coveralls.io/repos/github/XbyOrange/mercury-browser-storage/badge.svg
 [coveralls-url]: https://coveralls.io/github/XbyOrange/mercury-browser-storage

--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ npm i @xbyorange/mercury-browser-storage --save
 	* Arguments
 		* namespace - _`<String>`_. Namespace to be used in the sessionStorage object, in which the origin data will be persisted.
 		* defaultValue - _`<Any>`_ Default value until the first async read is resolved.
+		* options - `<Object>` containing properties:
+			* queriesDefaultValue - _`<Boolean>`_ If `true`, the default value of queried sources will be the value of the "key" in the query. If not defined, the default value of queried sources will be the full `defaultValue` object.
+			* tags - _`<String> or <Array of Strings>`_ Tags to assign to the instance. Useful when using [mercury `sources` handler][mercury-sources-docs-url]. Tags "browser-storage" and "session-storage" will be always added to provided tags by default.
 * LocalStorage - _`<Class>`_ `new LocalStorage(namespace[, defaultValue[, options]])` - Class for instancing mercury objects persisted in the browser localStorage.
 	* Arguments
 		* namespace - _`<String>`_. Namespace to be used in the localStorage object, in which the origin data will be persisted.
 		* defaultValue - _`<Any>`_ Default value until the first async read is resolved.
+		* options - `<Object>` containing properties:
+			* queriesDefaultValue - _`<Boolean>`_ If `true`, the default value of queried sources will be the value of the "key" in the query. If not defined, the default value of queried sources will be the full `defaultValue` object.
+			* tags - _`<String> or <Array of Strings>`_ Tags to assign to the instance. Useful when using [mercury `sources` handler][mercury-sources-docs-url]. Tags "browser-storage" and "local-storage" will be always added to provided tags by default.
 
 ## Common Methods
 
@@ -121,6 +127,7 @@ Contributors are welcome.
 Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of conduct](.github/CODE_OF_CONDUCT.md).
 
 [mercury-url]: https://github.com/xbyorange/mercury
+[mercury-sources-docs-url]: https://github.com/XbyOrange/mercury/blob/master/docs/sources/api.md
 [react-mercury-url]: https://github.com/xbyorange/react-mercury
 
 [coveralls-image]: https://coveralls.io/repos/github/XbyOrange/mercury-browser-storage/badge.svg

--- a/src/LocalStorage.js
+++ b/src/LocalStorage.js
@@ -1,7 +1,7 @@
 import { Storage } from "./Storage";
 
 export class LocalStorage extends Storage {
-  constructor(namespace, defaultValue, root) {
-    super(namespace, defaultValue, "localStorage", root);
+  constructor(namespace, defaultValue, options) {
+    super(namespace, defaultValue, "localStorage", options);
   }
 }

--- a/src/SessionStorage.js
+++ b/src/SessionStorage.js
@@ -1,7 +1,7 @@
 import { Storage } from "./Storage";
 
 export class SessionStorage extends Storage {
-  constructor(namespace, defaultValue, root) {
-    super(namespace, defaultValue, "sessionStorage", root);
+  constructor(namespace, defaultValue, options) {
+    super(namespace, defaultValue, "sessionStorage", options);
   }
 }

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -17,10 +17,12 @@ class StorageMock {
 }
 
 export class Storage extends Origin {
-  constructor(namespace, defaultValue, storageKey, root) {
-    super(`${storageKey}-${namespace}`, defaultValue);
+  constructor(namespace, defaultValue, storageKey, options = {}) {
+    super(null, defaultValue, {
+      uuid: namespace
+    });
     this._namespace = namespace;
-    this._storage = this._getStorage(storageKey, root);
+    this._storage = this._getStorage(storageKey, options.root);
   }
 
   _getStorage(storageKey, root) {

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -27,7 +27,13 @@ export class Storage extends Origin {
     const tags = Array.isArray(options.tags) ? options.tags : [options.tags];
     tags.push(TAG);
     tags.push(storageKeysTags[storageKey]);
-    super(null, defaultValue, {
+    const getDefaultValue = function(query) {
+      if (query && options.queriesDefaultValue) {
+        return defaultValue && defaultValue[query];
+      }
+      return defaultValue;
+    };
+    super(null, getDefaultValue, {
       uuid: namespace,
       tags
     });

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -2,6 +2,12 @@
 
 import { Origin } from "@xbyorange/mercury";
 
+const TAG = "browser-storage";
+const storageKeysTags = {
+  localStorage: "local-storage",
+  sessionStorage: "session-storage"
+};
+
 class StorageMock {
   constructor() {
     this._value = "{}";
@@ -18,8 +24,12 @@ class StorageMock {
 
 export class Storage extends Origin {
   constructor(namespace, defaultValue, storageKey, options = {}) {
+    const tags = Array.isArray(options.tags) ? options.tags : [options.tags];
+    tags.push(TAG);
+    tags.push(storageKeysTags[storageKey]);
     super(null, defaultValue, {
-      uuid: namespace
+      uuid: namespace,
+      tags
     });
     this._namespace = namespace;
     this._storage = this._getStorage(storageKey, options.root);

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -27,6 +27,11 @@ export class Storage extends Origin {
     const tags = Array.isArray(options.tags) ? options.tags : [options.tags];
     tags.push(TAG);
     tags.push(storageKeysTags[storageKey]);
+    if (!options.queriesDefaultValue) {
+      console.warn(
+        'Usage of "queriesDefaultValue" option is recommended to prepare your code for next major version of "mercury-browser-storage"'
+      );
+    }
     const getDefaultValue = function(query) {
       if (query && options.queriesDefaultValue) {
         return defaultValue && defaultValue[query];

--- a/test/local-storage-methods.spec.js
+++ b/test/local-storage-methods.spec.js
@@ -15,7 +15,13 @@ describe("Local Storage", () => {
 
   describe("Available methods", () => {
     it("should have all CRUD methods", () => {
-      const userData = new LocalStorage("userData", {}, storage.mock);
+      const userData = new LocalStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
       expect(userData.create).toBeDefined();
       expect(userData.read).toBeDefined();
       expect(userData.update).toBeDefined();
@@ -64,7 +70,13 @@ describe("Local Storage", () => {
     let userData;
 
     beforeAll(() => {
-      userData = new LocalStorage("userData", {}, storage.mock);
+      userData = new LocalStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     it("should be true while resource is being loaded, false when finished", () => {
@@ -115,7 +127,9 @@ describe("Local Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new LocalStorage("userData", undefined, storage.mock);
+      userData = new LocalStorage("userData", undefined, {
+        root: storage.mock
+      });
     });
 
     it("should be undefined while resource is being loaded, and returned value when finished successfully", () => {
@@ -150,7 +164,13 @@ describe("Local Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new LocalStorage("userData", {}, storage.mock);
+      userData = new LocalStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
     describe("without query", () => {
       it("should clean the cache when finish successfully", async () => {
@@ -207,7 +227,13 @@ describe("Local Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new LocalStorage("userData", {}, storage.mock);
+      userData = new LocalStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     it("should clean the cache when finish successfully", async () => {
@@ -240,7 +266,13 @@ describe("Local Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new LocalStorage("userData", {}, storage.mock);
+      userData = new LocalStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     it("should clean the cache when finish successfully", async () => {

--- a/test/local-storage-methods.spec.js
+++ b/test/local-storage-methods.spec.js
@@ -410,4 +410,12 @@ describe("Local Storage", () => {
       });
     });
   });
+
+  describe("Instance id", () => {
+    it("should be assigned based on first parameter", () => {
+      const FOO_ID = "foo-id";
+      const fooData = new LocalStorage(FOO_ID);
+      expect(sources.getById(FOO_ID).elements[0]).toEqual(fooData);
+    });
+  });
 });

--- a/test/local-storage-methods.spec.js
+++ b/test/local-storage-methods.spec.js
@@ -134,19 +134,33 @@ describe("Local Storage", () => {
       });
     });
 
-    it("should be undefined while resource is being loaded, and returned value when finished successfully", () => {
-      expect.assertions(2);
-      const promise = userData.read();
-      expect(userData.read.value).toEqual(undefined);
-      return promise.then(() => {
-        expect(userData.read.value).toEqual(fooData);
+    describe("without query", () => {
+      it("should be undefined while resource is being loaded, and returned value when finished successfully if no default value is defined", () => {
+        expect.assertions(2);
+        const promise = userData.read();
+        expect(userData.read.value).toEqual(undefined);
+        return promise.then(() => {
+          expect(userData.read.value).toEqual(fooData);
+        });
       });
-    });
 
-    it("should be accesible through getter", async () => {
-      expect.assertions(1);
-      await userData.read();
-      expect(userData.read.getters.value()).toEqual(fooData);
+      it("should be equal to default value while resource is being loaded, and returned value when finished successfully", () => {
+        expect.assertions(2);
+        userData = new LocalStorage("userData", fooData, {
+          root: storage.mock
+        });
+        const promise = userData.read();
+        expect(userData.read.value).toEqual(fooData);
+        return promise.then(() => {
+          expect(userData.read.value).toEqual(fooData);
+        });
+      });
+
+      it("should be accesible through getter", async () => {
+        expect.assertions(1);
+        await userData.read();
+        expect(userData.read.getters.value()).toEqual(fooData);
+      });
     });
 
     describe("when queried", () => {
@@ -154,6 +168,33 @@ describe("Local Storage", () => {
         let queriedData = userData.query("foo");
         const result = await queriedData.read();
         expect(result).toEqual("foo-value");
+      });
+
+      it("should return default value correspondent to query while resource is being loaded if queriesDefaultValue option is set", () => {
+        expect.assertions(2);
+        userData = new LocalStorage("userData", fooData, {
+          root: storage.mock,
+          queriesDefaultValue: true
+        });
+        let queriedData = userData.query("foo");
+        const promise = queriedData.read();
+        expect(queriedData.read.value).toEqual(fooData.foo);
+        return promise.then(() => {
+          expect(queriedData.read.value).toEqual(fooData.foo);
+        });
+      });
+
+      it("should return root default value if queriesDefaultValue option is not set", () => {
+        expect.assertions(2);
+        userData = new LocalStorage("userData", fooData, {
+          root: storage.mock
+        });
+        let queriedData = userData.query("foo");
+        const promise = queriedData.read();
+        expect(queriedData.read.value).toEqual(fooData);
+        return promise.then(() => {
+          expect(queriedData.read.value).toEqual(fooData.foo);
+        });
       });
     });
   });

--- a/test/local-storage-methods.spec.js
+++ b/test/local-storage-methods.spec.js
@@ -1,3 +1,4 @@
+const { sources } = require("@xbyorange/mercury");
 const Storage = require("./Storage.mock");
 
 const { LocalStorage } = require("../src/LocalStorage");
@@ -11,6 +12,7 @@ describe("Local Storage", () => {
 
   afterEach(() => {
     storage.restore();
+    sources.clear();
   });
 
   describe("Available methods", () => {
@@ -296,6 +298,75 @@ describe("Local Storage", () => {
           foo2: "foo-new"
         })
       );
+    });
+  });
+
+  describe("Instance tags", () => {
+    let fooData;
+
+    describe("when no options are defined", () => {
+      beforeEach(() => {
+        fooData = new LocalStorage("fooData");
+      });
+
+      it("should contain the browser-storage tag", () => {
+        expect(sources.getByTag("browser-storage").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain the local-storage tag", () => {
+        expect(sources.getByTag("local-storage").elements[0]).toEqual(fooData);
+      });
+    });
+
+    describe("when passing tags", () => {
+      it("should contain the local-storage tag even when a custom tag is received", () => {
+        const fooData = new LocalStorage(
+          "fooData",
+          {},
+          {
+            tags: "foo-tag"
+          }
+        );
+        expect(sources.getByTag("local-storage").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain the ocal-storage tag even when an array of custom tags is received", () => {
+        const fooData = new LocalStorage(
+          "fooData",
+          {},
+          {
+            tags: ["foo-tag", "foo-tag-2"]
+          }
+        );
+        expect(sources.getByTag("local-storage").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tag if received", () => {
+        const FOO_TAG = "foo-tag";
+        const fooData = new LocalStorage(
+          "fooData",
+          {},
+          {
+            tags: FOO_TAG
+          }
+        );
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tags if received", () => {
+        expect.assertions(2);
+        const FOO_TAG = "foo-tag";
+        const FOO_TAG_2 = "foo-tag-2";
+        const fooData = new LocalStorage(
+          "fooData",
+          {},
+          {
+            tags: [FOO_TAG, FOO_TAG_2]
+          }
+        );
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+        expect(sources.getByTag(FOO_TAG_2).elements[0]).toEqual(fooData);
+      });
     });
   });
 });

--- a/test/session-storage-methods.spec.js
+++ b/test/session-storage-methods.spec.js
@@ -386,4 +386,12 @@ describe("SessionStorage Storage", () => {
       });
     });
   });
+
+  describe("Instance id", () => {
+    it("should be assigned based on first parameter", () => {
+      const FOO_ID = "foo-id";
+      const fooData = new SessionStorage(FOO_ID);
+      expect(sources.getById(FOO_ID).elements[0]).toEqual(fooData);
+    });
+  });
 });

--- a/test/session-storage-methods.spec.js
+++ b/test/session-storage-methods.spec.js
@@ -103,19 +103,39 @@ describe("SessionStorage Storage", () => {
       });
     });
 
-    it("should be undefined while resource is being loaded, and returned value when finished successfully", () => {
-      expect.assertions(2);
-      const promise = userData.read();
-      expect(userData.read.value).toEqual(undefined);
-      return promise.then(() => {
-        expect(userData.read.value).toEqual(fooData);
+    describe("without query", () => {
+      it("should be undefined while resource is being loaded, and returned value when finished successfully if no default value is defined", () => {
+        expect.assertions(2);
+        const promise = userData.read();
+        expect(userData.read.value).toEqual(undefined);
+        return promise.then(() => {
+          expect(userData.read.value).toEqual(fooData);
+        });
       });
-    });
 
-    it("should be accesible through getter", async () => {
-      expect.assertions(1);
-      await userData.read();
-      expect(userData.read.getters.value()).toEqual(fooData);
+      it("should be equal to default value while resource is being loaded, and returned value when finished successfully", () => {
+        expect.assertions(2);
+        userData = new SessionStorage("userData", fooData, {
+          root: storage.mock
+        });
+        const promise = userData.read();
+        expect(userData.read.value).toEqual(fooData);
+        return promise.then(() => {
+          expect(userData.read.value).toEqual(fooData);
+        });
+      });
+
+      it("should be accesible through getter", async () => {
+        expect.assertions(1);
+        await userData.read();
+        expect(userData.read.getters.value()).toEqual(fooData);
+      });
+
+      it("should be accesible through getter", async () => {
+        expect.assertions(1);
+        await userData.read();
+        expect(userData.read.getters.value()).toEqual(fooData);
+      });
     });
 
     describe("when queried", () => {
@@ -123,6 +143,33 @@ describe("SessionStorage Storage", () => {
         let queriedData = userData.query("foo");
         const result = await queriedData.read();
         expect(result).toEqual("foo-value");
+      });
+
+      it("should return default value correspondent to query while resource is being loaded if queriesDefaultValue option is set", () => {
+        expect.assertions(2);
+        userData = new SessionStorage("userData", fooData, {
+          root: storage.mock,
+          queriesDefaultValue: true
+        });
+        let queriedData = userData.query("foo");
+        const promise = queriedData.read();
+        expect(queriedData.read.value).toEqual(fooData.foo);
+        return promise.then(() => {
+          expect(queriedData.read.value).toEqual(fooData.foo);
+        });
+      });
+
+      it("should return root default value if queriesDefaultValue option is not set", () => {
+        expect.assertions(2);
+        userData = new SessionStorage("userData", fooData, {
+          root: storage.mock
+        });
+        let queriedData = userData.query("foo");
+        const promise = queriedData.read();
+        expect(queriedData.read.value).toEqual(fooData);
+        return promise.then(() => {
+          expect(queriedData.read.value).toEqual(fooData.foo);
+        });
       });
     });
   });

--- a/test/session-storage-methods.spec.js
+++ b/test/session-storage-methods.spec.js
@@ -1,3 +1,4 @@
+const { sources } = require("@xbyorange/mercury");
 const Storage = require("./Storage.mock");
 
 const { SessionStorage } = require("../src/SessionStorage");
@@ -11,6 +12,7 @@ describe("SessionStorage Storage", () => {
 
   afterEach(() => {
     storage.restore();
+    sources.clear();
   });
 
   describe("Available methods", () => {
@@ -266,6 +268,75 @@ describe("SessionStorage Storage", () => {
           foo2: "foo-new"
         })
       );
+    });
+  });
+
+  describe("Instance tags", () => {
+    let fooData;
+
+    describe("when no options are defined", () => {
+      beforeEach(() => {
+        fooData = new SessionStorage("fooData");
+      });
+
+      it("should contain the browser-storage tag", () => {
+        expect(sources.getByTag("browser-storage").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain the session-storage tag", () => {
+        expect(sources.getByTag("session-storage").elements[0]).toEqual(fooData);
+      });
+    });
+
+    describe("when passing tags", () => {
+      it("should contain the session-storage tag even when a custom tag is received", () => {
+        const fooData = new SessionStorage(
+          "fooData",
+          {},
+          {
+            tags: "foo-tag"
+          }
+        );
+        expect(sources.getByTag("session-storage").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain the session-storage tag even when an array of custom tags is received", () => {
+        const fooData = new SessionStorage(
+          "fooData",
+          {},
+          {
+            tags: ["foo-tag", "foo-tag-2"]
+          }
+        );
+        expect(sources.getByTag("session-storage").elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tag if received", () => {
+        const FOO_TAG = "foo-tag";
+        const fooData = new SessionStorage(
+          "fooData",
+          {},
+          {
+            tags: FOO_TAG
+          }
+        );
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+      });
+
+      it("should contain defined custom tags if received", () => {
+        expect.assertions(2);
+        const FOO_TAG = "foo-tag";
+        const FOO_TAG_2 = "foo-tag-2";
+        const fooData = new SessionStorage(
+          "fooData",
+          {},
+          {
+            tags: [FOO_TAG, FOO_TAG_2]
+          }
+        );
+        expect(sources.getByTag(FOO_TAG).elements[0]).toEqual(fooData);
+        expect(sources.getByTag(FOO_TAG_2).elements[0]).toEqual(fooData);
+      });
     });
   });
 });

--- a/test/session-storage-methods.spec.js
+++ b/test/session-storage-methods.spec.js
@@ -15,7 +15,13 @@ describe("SessionStorage Storage", () => {
 
   describe("Available methods", () => {
     it("should have all CRUD methods", () => {
-      const userData = new SessionStorage("userData", {}, storage.mock);
+      const userData = new SessionStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
       expect(userData.create).toBeDefined();
       expect(userData.read).toBeDefined();
       expect(userData.update).toBeDefined();
@@ -33,7 +39,13 @@ describe("SessionStorage Storage", () => {
     let userData;
 
     beforeAll(() => {
-      userData = new SessionStorage("userData", {}, storage.mock);
+      userData = new SessionStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     it("should be true while resource is being loaded, false when finished", () => {
@@ -84,7 +96,9 @@ describe("SessionStorage Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new SessionStorage("userData", undefined, storage.mock);
+      userData = new SessionStorage("userData", undefined, {
+        root: storage.mock
+      });
     });
 
     it("should be undefined while resource is being loaded, and returned value when finished successfully", () => {
@@ -119,7 +133,13 @@ describe("SessionStorage Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new SessionStorage("userData", {}, storage.mock);
+      userData = new SessionStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     describe("without query", () => {
@@ -177,7 +197,13 @@ describe("SessionStorage Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new SessionStorage("userData", {}, storage.mock);
+      userData = new SessionStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     it("should clean the cache when finish successfully", async () => {
@@ -210,7 +236,13 @@ describe("SessionStorage Storage", () => {
 
     beforeEach(() => {
       storage.stubs.getItem.returns(JSON.stringify(fooData));
-      userData = new SessionStorage("userData", {}, storage.mock);
+      userData = new SessionStorage(
+        "userData",
+        {},
+        {
+          root: storage.mock
+        }
+      );
     });
 
     it("should clean the cache when finish successfully", async () => {


### PR DESCRIPTION
### Added
- Add "queriesDefaultValue" option. If defined, queried instances will have default value corresponding to the value of query "key" in the default value object. If not, the behavior of "default value" will be the same than in previous versions, and will return the full object even for queried instances)
- Add "tags" option.
